### PR TITLE
Allocating static arrays.

### DIFF
--- a/idioms/One does not simply call new for static arrays.md
+++ b/idioms/One does not simply call new for static arrays.md
@@ -26,17 +26,14 @@ void main()
 }
 ```
 
-But this can't be with static arrays, despite them being [value types](#Static-arrays-are-value-types).
-Doesn't that sound like an inconsistency? Something that would have to be **explained.**
+But this can't be with static arrays, despite them being [value types](#Static-arrays-are-value-types). Doesn't that sound like an inconsistency? Something that would have to be **explained.**
 
 ## Why?
 
-The reasoning for `new` and static arrays was probably that you rarely really want to allocate a static
-array on the heap; it could just as well be a slice.
+The reasoning for `new` and static arrays was probably that you rarely really want to allocate a static array on the heap; it could just as well be a slice.
 
 **So there is no syntax to do this**.
-When you do write `new int[4]` this will instead return an `int[]` _slice_ with a length of 4, which adds
-the benefits of dynamic arrays.
+When you do write `new int[4]` this will instead return an `int[]` _slice_ with a length of 4, which adds the benefits of dynamic arrays.
 
 ```
 writeln(typeof(new int[4]).stringof); // output: "int[]"
@@ -53,9 +50,7 @@ So far, so good.
 
 ## Do it anyway
 
-If for some reason you really need a _static_ array allocated on the heap instead of a slice, you can do it
-anyway by using `std.experimental.allocator` (or its DUB equivalent
-[stdx-allocator](https://code.dlang.org/packages/stdx-allocator)):
+If for some reason you really need a _static_ array allocated on the heap instead of a slice, you can do it anyway by using `std.experimental.allocator` (or its DUB equivalent [stdx-allocator](https://code.dlang.org/packages/stdx-allocator)):
 
 ```
 import std.experimental.allocator;

--- a/idioms/One does not simply call new for static arrays.md
+++ b/idioms/One does not simply call new for static arrays.md
@@ -5,9 +5,7 @@ One does not simply call `new` for static arrays
 It just happens that in D you can't use `new` to get a pointer to a newly allocated static array.
 
 ```
-import std.stdio;
-
-void main(string[] args)
+void main()
 {
     alias T = int[4];
 
@@ -22,9 +20,7 @@ _"You can only call new with structs, dynamic arrays, and class objects"_ says t
 **Unrelated:** actually the compiler is lying a bit, since it is possible to allocate a single (builtin type) value on the heap:
 
 ```
-import std.stdio;
-
-void main(string[] args)
+void main()
 {
     int* p = new int;  // Works
 }

--- a/index.html
+++ b/index.html
@@ -413,9 +413,7 @@ vim-hybrid theme by w0ng (https://github.com/w0ng/vim-hybrid)
 <title>d-idioms - Idioms for the D programming language</title></head><body><script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create', 'UA-71912218-1', 'auto');ga('send', 'pageview');</script><script src="highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 <header><img id="logo" src="d-logo.svg"></img><div id="title-container"><div id="title">Idioms for the D Programming Language
-<br><div id="sub-title"><b>ἰδῐόω</b> (idióō): peculiarity, specific property, unique feature.</div></div></div></header><nav><div class="item-nav"><a href="#Inside-the-D-Object-Model">Inside the D Object Model
-</a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Created Feb 3<span class="sub">rd</span> 2019
-</span></div><div class="item-nav"><a href="#Contributing-back-with-money">Contributing back with money
+<br><div id="sub-title"><b>ἰδῐόω</b> (idióō): peculiarity, specific property, unique feature.</div></div></div></header><nav><div class="item-nav"><a href="#Contributing-back-with-money">Contributing back with money
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Feb 3<span class="sub">rd</span> 2019, created Mar 1<span class="sub">st</span> 2018
 </span></div><div class="item-nav"><a href="#Working-with-files">Working with files
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Sep 25<span class="sub">th</span> 2018, created Oct 4<span class="sub">th</span> 2015
@@ -429,6 +427,8 @@ vim-hybrid theme by w0ng (https://github.com/w0ng/vim-hybrid)
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified May 6<span class="sub">th</span> 2018, created Jan 10<span class="sub">th</span> 2015
 </span></div><div class="item-nav"><a href="#So-what-does--debug-do,-exactly&#63;">So what does -debug do, exactly&#63;
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Created Apr 18<span class="sub">th</span> 2018
+</span></div><div class="item-nav"><a href="#Inside-the-D-object-model">Inside the D object model
+</a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Created Feb 9<span class="sub">th</span> 2018
 </span></div><div class="item-nav"><a href="#Differences-in-integer-handling-vs-C">Differences in integer handling vs C
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Feb 9<span class="sub">th</span> 2018, created Feb 14<span class="sub">th</span> 2016
 </span></div><div class="item-nav"><a href="#Games-made-with-D">Games made with D
@@ -569,15 +569,7 @@ vim-hybrid theme by w0ng (https://github.com/w0ng/vim-hybrid)
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Jan 8<span class="sub">th</span> 2015, created Jan 4<span class="sub">th</span> 2015
 </span></div><div class="item-nav"><a href="#Inheriting-from-Exception">Inheriting from Exception
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Jan 7<span class="sub">th</span> 2015, created Jan 4<span class="sub">th</span> 2015
-</span></div></nav><div class="container"><a name="Inside-the-D-Object-Model"></a><div class="idiom"><a class="permalink" href="#Inside-the-D-Object-Model">Link
-</a><h1 id="inside-the-d-object-model">Inside the D Object Model</h1>
-<p>How are inheritance and multiple interfaces implemented?
-</p>
-<p>This blog post by Mathis Beer explains the layout of "Single Inheritance Multiple Interfaces" objects, with graphics:<br/><a href="https://feepingcreature.github.io/oop.html">https://feepingcreature.github.io/oop.html</a>
-</p>
-<p><strong>TL;DR: For each interface implemented by a class instance, there is a hidden field. That field pointing to the corresponding v-table subset.</strong> 
-</p>
-</div><a name="Contributing-back-with-money"></a><div class="idiom"><a class="permalink" href="#Contributing-back-with-money">Link
+</span></div></nav><div class="container"><a name="Contributing-back-with-money"></a><div class="idiom"><a class="permalink" href="#Contributing-back-with-money">Link
 </a><h1 id="contributing-back-with-money">Contributing back with money</h1>
 <p>While the D phenomenon relies primarily on benevolent effort, a bit of money can go a long way towards enhancing documentation, supporting libraries, compilers and IDEs.
 </p>
@@ -791,6 +783,14 @@ else
 <p><strong>Breaking</strong> <code class="prettyprint">pure</code>/<code class="prettyprint">@nogc</code>/<code class="prettyprint">nothrow</code>/<code class="prettyprint">@safe</code> <strong>with</strong> <code class="prettyprint">-debug</code> <strong>is Undefined Behaviour</strong>, though in most cases it will work just fine and you don't have to worry. Just <strong>don't ship code with -debug</strong> enabled.
 </p>
 <p>Read more about <code class="prettyprint">-debug</code>: <a href="https://dlang.org/dmd-windows.html#switch-debug">https://dlang.org/dmd-windows.html#switch-debug</a>
+</p>
+</div><a name="Inside-the-D-object-model"></a><div class="idiom"><a class="permalink" href="#Inside-the-D-object-model">Link
+</a><h1 id="inside-the-d-object-model">Inside the D Object Model</h1>
+<p>How are inheritance and multiple interfaces implemented?
+</p>
+<p>This blog post by Mathis Beer explains the layout of "Single Inheritance Multiple Interfaces" objects, with graphics:<br/><a href="https://feepingcreature.github.io/oop.html">https://feepingcreature.github.io/oop.html</a>
+</p>
+<p><strong>TL;DR: For each interface implemented by a class instance, there is a hidden field. That field pointing to the corresponding v-table subset.</strong> 
 </p>
 </div><a name="Differences-in-integer-handling-vs-C"></a><div class="idiom"><a class="permalink" href="#Differences-in-integer-handling-vs-C">Link
 </a><h1 id="differences-in-integer-handling-vs-c">Differences in integer handling vs C</h1>

--- a/index.html
+++ b/index.html
@@ -661,9 +661,7 @@ void main(string[] args)
 </a><h1 id="one-does-not-simply-call-new-for-static-arrays">One does not simply call <code class="prettyprint">new</code> for static arrays</h1>
 <p>It just happens that in D you can't use <code class="prettyprint">new</code> to get a pointer to a newly allocated static array.
 </p>
-<pre class="prettyprint"><code>import std.stdio;
-
-void main(string[] args)
+<pre class="prettyprint"><code>void main()
 {
     alias T = int[4];
 
@@ -675,9 +673,7 @@ void main(string[] args)
 </p>
 <p><strong>Unrelated:</strong> actually the compiler is lying a bit, since it is possible to allocate a single (builtin type) value on the heap:
 </p>
-<pre class="prettyprint"><code>import std.stdio;
-
-void main(string[] args)
+<pre class="prettyprint"><code>void main()
 {
     int* p = new int;  // Works
 }

--- a/index.html
+++ b/index.html
@@ -413,15 +413,15 @@ vim-hybrid theme by w0ng (https://github.com/w0ng/vim-hybrid)
 <title>d-idioms - Idioms for the D programming language</title></head><body><script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create', 'UA-71912218-1', 'auto');ga('send', 'pageview');</script><script src="highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 <header><img id="logo" src="d-logo.svg"></img><div id="title-container"><div id="title">Idioms for the D Programming Language
-<br><div id="sub-title"><b>ἰδῐόω</b> (idióō): peculiarity, specific property, unique feature.</div></div></div></header><nav><div class="item-nav"><a href="#Contributing-back-with-money">Contributing back with money
+<br><div id="sub-title"><b>ἰδῐόω</b> (idióō): peculiarity, specific property, unique feature.</div></div></div></header><nav><div class="item-nav"><a href="#One-does-not-simply-call-new-for-static-arrays">One does not simply call new for static arrays
+</a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Feb 23<span class="sub">th</span> 2019, created May 6<span class="sub">th</span> 2018
+</span></div><div class="item-nav"><a href="#Contributing-back-with-money">Contributing back with money
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Feb 3<span class="sub">rd</span> 2019, created Mar 1<span class="sub">st</span> 2018
 </span></div><div class="item-nav"><a href="#Working-with-files">Working with files
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Sep 25<span class="sub">th</span> 2018, created Oct 4<span class="sub">th</span> 2015
 </span></div><div class="item-nav"><a href="#Voldemort-types">Voldemort types
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Sep 16<span class="sub">th</span> 2018, created Jan 5<span class="sub">th</span> 2016
 </span></div><div class="item-nav"><a href="#Type-qualifiers-and-slices-creation">Type qualifiers and slices creation
-</a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Created May 6<span class="sub">th</span> 2018
-</span></div><div class="item-nav"><a href="#One-does-not-simply-call-new-for-static-arrays">One does not simply call new for static arrays
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Created May 6<span class="sub">th</span> 2018
 </span></div><div class="item-nav"><a href="#Static-arrays-are-value-types">Static arrays are value types
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified May 6<span class="sub">th</span> 2018, created Jan 10<span class="sub">th</span> 2015
@@ -569,7 +569,62 @@ vim-hybrid theme by w0ng (https://github.com/w0ng/vim-hybrid)
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Jan 8<span class="sub">th</span> 2015, created Jan 4<span class="sub">th</span> 2015
 </span></div><div class="item-nav"><a href="#Inheriting-from-Exception">Inheriting from Exception
 </a><span style=" color:rgb(158,158,158); font-size: 0.7em; float: right;"> Modified Jan 7<span class="sub">th</span> 2015, created Jan 4<span class="sub">th</span> 2015
-</span></div></nav><div class="container"><a name="Contributing-back-with-money"></a><div class="idiom"><a class="permalink" href="#Contributing-back-with-money">Link
+</span></div></nav><div class="container"><a name="One-does-not-simply-call-new-for-static-arrays"></a><div class="idiom"><a class="permalink" href="#One-does-not-simply-call-new-for-static-arrays">Link
+</a><h1 id="one-does-not-simply-call-new-for-static-arrays">One does not simply call <code class="prettyprint">new</code> for static arrays</h1>
+<p>It just happens that in D you can't use <code class="prettyprint">new</code> to get a pointer to a newly allocated static array.
+</p>
+<pre class="prettyprint"><code>void main()
+{
+    alias T = int[4];
+
+    // This line does not compile!
+    // Error: new can only create structs, dynamic arrays or class objects, not int[4]'s
+    auto t = new T; 
+}
+</code></pre><p><em>"You can only call new with structs, dynamic arrays, and class objects"</em> says the compiler.
+</p>
+<p><strong>Unrelated:</strong> actually the compiler is lying a bit, since it is possible to allocate a single (builtin type) value on the heap:
+</p>
+<pre class="prettyprint"><code>void main()
+{
+    int* p = new int;  // Works
+}
+</code></pre><p>But this can't be with static arrays, despite them being <a href="#Static-arrays-are-value-types">value types</a>.<br/>Doesn't that sound like an inconsistency? Something that would have to be <strong>explained.</strong>
+</p>
+<h2 id="why"> Why?</h2>
+<p>The reasoning for <code class="prettyprint">new</code> and static arrays was probably that you rarely really want to allocate a static<br/>array on the heap; it could just as well be a slice.
+</p>
+<p><strong>So there is no syntax to do this</strong>.<br/>When you do write <code class="prettyprint">new int[4]</code> this will instead return an <code class="prettyprint">int[]</code> <em>slice</em> with a length of 4, which adds<br/>the benefits of dynamic arrays.
+</p>
+<pre class="prettyprint"><code>writeln(typeof(new int[4]).stringof); // output: "int[]"
+
+auto arr = new int[4];
+writeln(arr.length); // output: "4"
+arr ~= 42;
+writeln(arr.length); // output: "5"
+</code></pre><p>So far, so good. 
+</p>
+<p><a href="#Type-qualifiers-and-slices-creation">It gets weirder</a> whenever <code class="prettyprint">shared</code>, <code class="prettyprint">const</code> and <code class="prettyprint">immutable</code> get introduced...
+</p>
+<h2 id="do-it-anyway"> Do it anyway</h2>
+<p>If for some reason you really need a <em>static</em> array allocated on the heap instead of a slice, you can do it<br/>anyway by using <code class="prettyprint">std.experimental.allocator</code> (or its DUB equivalent<br/><a href="https://code.dlang.org/packages/stdx-allocator">stdx-allocator</a>):
+</p>
+<pre class="prettyprint"><code>import std.experimental.allocator;
+
+void main()
+{
+    alias T = int[4];
+
+ // T* t = new T;                 // Won't work.
+    T* t = theAllocator.make!T;   // Fine!
+    assert((*t).length == 4);     // Safe too.
+
+    (*t)[1] = 42;                 // Needs pointer dereference and parentheses before use.
+    assert(*t == [0, 42, 0, 0]);  // Features default initialization.
+    
+ // (*t) ~= 43; // Error: cannot append type int to type int[4]
+}
+</code></pre></div><a name="Contributing-back-with-money"></a><div class="idiom"><a class="permalink" href="#Contributing-back-with-money">Link
 </a><h1 id="contributing-back-with-money">Contributing back with money</h1>
 <p>While the D phenomenon relies primarily on benevolent effort, a bit of money can go a long way towards enhancing documentation, supporting libraries, compilers and IDEs.
 </p>
@@ -656,39 +711,6 @@ void main(string[] args)
 </code></pre><p><strong>Note:</strong> this syntax <a href="#One-does-not-simply-call-new-for-static-arrays">doesn't return pointers to static arrays</a> but indeed return a slice.
 </p>
 <p><em>This peculiarity was emphasized at DConf 2018 by Andrei Alexandrescu.</em>
-</p>
-</div><a name="One-does-not-simply-call-new-for-static-arrays"></a><div class="idiom"><a class="permalink" href="#One-does-not-simply-call-new-for-static-arrays">Link
-</a><h1 id="one-does-not-simply-call-new-for-static-arrays">One does not simply call <code class="prettyprint">new</code> for static arrays</h1>
-<p>It just happens that in D you can't use <code class="prettyprint">new</code> to get a pointer to a newly allocated static array.
-</p>
-<pre class="prettyprint"><code>void main()
-{
-    alias T = int[4];
-
-    // This line does not compile!
-    // Error: new can only create structs, dynamic arrays or class objects, not int[4]'s
-    auto t = new T; 
-}
-</code></pre><p><em>"You can only call new with structs, dynamic arrays, and class objects"</em> says the compiler.
-</p>
-<p><strong>Unrelated:</strong> actually the compiler is lying a bit, since it is possible to allocate a single (builtin type) value on the heap:
-</p>
-<pre class="prettyprint"><code>void main()
-{
-    int* p = new int;  // Works
-}
-</code></pre><p>But this can't be with static arrays, despite them being <a href="#Static-arrays-are-value-types">value types</a>.<br/>Doesn't that sound like an inconsistency? Something that would have to be <strong>explained.</strong>
-</p>
-<h2 id="why"> Why?</h2>
-<p>The reasoning for <code class="prettyprint">new</code> and static arrays was probably that you never really want to allocate a static array on the heap <em>and then get a raw pointer on that memory</em>.<br/>It could as well be a slice with little to no speed loss.
-</p>
-<p><strong>So there is no syntax to do this</strong>.<br/>When you do write <code class="prettyprint">new int[4]</code> this will instead return a <code class="prettyprint">int[]</code> <em>slice</em> with a length of 4. <br/>Like all slices it comes with a length, which is safer.
-</p>
-<pre class="prettyprint"><code>writeln(typeof(new int[4]).stringof); // output: "int[]"
-writeln((new int[4]).length); // output: "4"
-</code></pre><p>So far, so good. 
-</p>
-<p><a href="#Type-qualifiers-and-slices-creation">It gets weirder</a> whenever <code class="prettyprint">shared</code>, <code class="prettyprint">const</code> and <code class="prettyprint">immutable</code> get introduced...
 </p>
 </div><a name="Static-arrays-are-value-types"></a><div class="idiom"><a class="permalink" href="#Static-arrays-are-value-types">Link
 </a><h1 id="static-arrays-are-value-types">Static arrays are value types</h1>

--- a/index.html
+++ b/index.html
@@ -589,12 +589,12 @@ vim-hybrid theme by w0ng (https://github.com/w0ng/vim-hybrid)
 {
     int* p = new int;  // Works
 }
-</code></pre><p>But this can't be with static arrays, despite them being <a href="#Static-arrays-are-value-types">value types</a>.<br/>Doesn't that sound like an inconsistency? Something that would have to be <strong>explained.</strong>
+</code></pre><p>But this can't be with static arrays, despite them being <a href="#Static-arrays-are-value-types">value types</a>. Doesn't that sound like an inconsistency? Something that would have to be <strong>explained.</strong>
 </p>
 <h2 id="why"> Why?</h2>
-<p>The reasoning for <code class="prettyprint">new</code> and static arrays was probably that you rarely really want to allocate a static<br/>array on the heap; it could just as well be a slice.
+<p>The reasoning for <code class="prettyprint">new</code> and static arrays was probably that you rarely really want to allocate a static array on the heap; it could just as well be a slice.
 </p>
-<p><strong>So there is no syntax to do this</strong>.<br/>When you do write <code class="prettyprint">new int[4]</code> this will instead return an <code class="prettyprint">int[]</code> <em>slice</em> with a length of 4, which adds<br/>the benefits of dynamic arrays.
+<p><strong>So there is no syntax to do this</strong>.<br/>When you do write <code class="prettyprint">new int[4]</code> this will instead return an <code class="prettyprint">int[]</code> <em>slice</em> with a length of 4, which adds the benefits of dynamic arrays.
 </p>
 <pre class="prettyprint"><code>writeln(typeof(new int[4]).stringof); // output: "int[]"
 
@@ -607,7 +607,7 @@ writeln(arr.length); // output: "5"
 <p><a href="#Type-qualifiers-and-slices-creation">It gets weirder</a> whenever <code class="prettyprint">shared</code>, <code class="prettyprint">const</code> and <code class="prettyprint">immutable</code> get introduced...
 </p>
 <h2 id="do-it-anyway"> Do it anyway</h2>
-<p>If for some reason you really need a <em>static</em> array allocated on the heap instead of a slice, you can do it<br/>anyway by using <code class="prettyprint">std.experimental.allocator</code> (or its DUB equivalent<br/><a href="https://code.dlang.org/packages/stdx-allocator">stdx-allocator</a>):
+<p>If for some reason you really need a <em>static</em> array allocated on the heap instead of a slice, you can do it anyway by using <code class="prettyprint">std.experimental.allocator</code> (or its DUB equivalent <a href="https://code.dlang.org/packages/stdx-allocator">stdx-allocator</a>):
 </p>
 <pre class="prettyprint"><code>import std.experimental.allocator;
 

--- a/index.html
+++ b/index.html
@@ -3433,4 +3433,5 @@ assert(indexOf("Hello home sweet home", "home") == 6);
 </h2><ul id="contributors"><li><a href="https://github.com/BBasile">Basile Burg
 </a></li><li><a href="https://github.com/bubnenkoff">Dmitry Bubnenkov
 </a></li><li><a href="https://github.com/yannick">Yannick Koechlin
+</a></li><li><a href="https://github.com/veelo">Bastiaan Veelo
 </a></li></ul></footer></body></html>

--- a/source/main.d
+++ b/source/main.d
@@ -239,6 +239,7 @@ void main(string[] args)
                             Contributor("Basile Burg", "https://github.com/BBasile"),
                             Contributor("Dmitry Bubnenkov", "https://github.com/bubnenkoff"),
                             Contributor("Yannick Koechlin", "https://github.com/yannick"),
+                            Contributor("Bastiaan Veelo", "https://github.com/veelo"),
                         ];
 
                         push("h2");


### PR DESCRIPTION
Hi Guillaume,

Here's my rework of your "One does not simply call new for static arrays" idiom.

1. It shows a way to actually allocate a static array on the heap.
2. It removes the bit about raw pointers and missing length, as this method is both type safe and bounds safe.
3. It clarifies the real benefit of slices as they implement dynamic arrays. (Though I didn't highlight slices referencing common data, that would be OT I think.)

I shamelessly added myself to the (incomplete?) list of contributors, hope that's alright. Dub has been run and `index.html` regenerated.

Closes issue #156.

Hope you like it,
Bastiaan.