### PR TITLE
Fix broken link in Phobos gems

### DIFF
--- a/idioms/Phobos gems.md
+++ b/idioms/Phobos gems.md
@@ -50,4 +50,4 @@ See: [http://dlang.org/phobos/std_array.html#.array](http://dlang.org/phobos/std
 
 - [Hidden treasure in the D standard library](http://nomad.so/2014/08/hidden-treasure-in-the-d-standard-library/)
 
-- [http://nomad.so/2015/08/more-hidden-treasure-in-the-d-standard-library/](http://nomad.so/2015/08/more-hidden-treasure-in-the-d-standard-library/)
+- [http://nomad.uk.net/articles/more-hidden-treasure-in-the-d-standard-library.html](http://nomad.uk.net/articles/more-hidden-treasure-in-the-d-standard-library.html)


### PR DESCRIPTION
I think this is what it's supposed to refer to.

Edit:
https://github.com/p0nce/d-idioms/blob/gh-pages/idioms/People%20blogging%20about%20D.md

Is outdated too, but I don't know how to get a list of D posts there. So maybe that can become simply http://nomad.uk.net/pages/archive.html?